### PR TITLE
Add definition resource for retrieving api definition per app

### DIFF
--- a/resources/api/twintip-api.yaml
+++ b/resources/api/twintip-api.yaml
@@ -164,6 +164,22 @@ paths:
         default:
           $ref: '#/responses/Error'
 
+  '/apps/{application_id}/definition':
+    get:
+      summary: read API definition
+      description: |
+        Returns crawled OpenAPI definition of one API
+      tags:
+      - APIs
+      operationId: 'org.zalando.stups.twintip.storage.api/read-api-definition'
+      parameters:
+      - $ref: '#/parameters/ApplicationID'
+      responses:
+        200:
+          description: OpenAPI definition of one API
+          schema:
+            type: object
+
 # definitions
 
 parameters:

--- a/resources/db/apis.sql
+++ b/resources/db/apis.sql
@@ -28,6 +28,11 @@ SELECT application_id, status, type, name, version, url, ui, definition
   FROM api
  WHERE application_id = :application_id;
 
+ --name: read-api-definition
+ SELECT definition
+   FROM api
+  WHERE application_id = :application_id;
+
 -- name: create-or-update-api!
 WITH api_update AS (
      UPDATE api

--- a/src/org/zalando/stups/twintip/storage/api.clj
+++ b/src/org/zalando/stups/twintip/storage/api.clj
@@ -17,7 +17,9 @@
             [org.zalando.stups.twintip.storage.sql :as sql]
             [ring.util.response :refer :all]
             [org.zalando.stups.friboo.ring :refer :all]
-            [org.zalando.stups.friboo.log :as log]))
+            [org.zalando.stups.friboo.log :as log]
+            [cheshire.core :as json]
+            [clojure.pprint :refer [pprint]]))
 
 ; define the API component and its dependencies
 (def-http-component API "api/twintip-api.yaml" [db])
@@ -47,6 +49,13 @@
         {:connection db})
       (single-response)
       (content-type-json)))
+
+(defn read-api-definition [{:keys [application_id]} _ db]
+  (log/debug "Read API %s definition." application_id)
+  (let [result (:definition (first (sql/cmd-read-api-definition
+                                     {:application_id application_id}
+                                     {:connection db})))]
+    (content-type-json (response result))))
 
 (defn create-or-update-api! [{:keys [apidef application_id]} _ db]
   (sql/cmd-create-or-update-api!

--- a/src/org/zalando/stups/twintip/storage/api.clj
+++ b/src/org/zalando/stups/twintip/storage/api.clj
@@ -18,8 +18,7 @@
             [ring.util.response :refer :all]
             [org.zalando.stups.friboo.ring :refer :all]
             [org.zalando.stups.friboo.log :as log]
-            [cheshire.core :as json]
-            [clojure.pprint :refer [pprint]]))
+            [cheshire.core :as json]))
 
 ; define the API component and its dependencies
 (def-http-component API "api/twintip-api.yaml" [db])

--- a/src/org/zalando/stups/twintip/storage/api.clj
+++ b/src/org/zalando/stups/twintip/storage/api.clj
@@ -17,8 +17,7 @@
             [org.zalando.stups.twintip.storage.sql :as sql]
             [ring.util.response :refer :all]
             [org.zalando.stups.friboo.ring :refer :all]
-            [org.zalando.stups.friboo.log :as log]
-            [cheshire.core :as json]))
+            [org.zalando.stups.friboo.log :as log]))
 
 ; define the API component and its dependencies
 (def-http-component API "api/twintip-api.yaml" [db])


### PR DESCRIPTION
Adds an endpoint which can be used to retrieve whole api definition of one app which was crawled by twintip-crawler. This enhancement enables a big simplification of swagger-ui afterwards. At the moment, Swagger UI is loading service url of specific app from kio and loads the api definition directly from the specific app, although the definition is already present in the twintip-storage.